### PR TITLE
feat: Integrate LZ4 decompression for LoxCC files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ lib copy.rs
 src/loxwebsocket/cython_modules/extractor_compatible.c
 src/loxwebsocket/cython_modules/extractor_optimized.c
 newbench.py
+config/sps0.LoxCC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "construct>=2.10.70",
     "tomlkit>=0.13.0",
     "lxml>=6.0.0",
-    "loxwebsocket>=0.5.1"
+    "loxwebsocket>=0.5.1",
+    "lz4>=4.4.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
 Integrate LZ4 decompression for LoxCC files - way faster

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches LoxCC decompression to LZ4 with frame/block auto-detection, adds strict payload validation, and includes the lz4 dependency.
> 
> - **Backend (miniserver_sync)**:
>   - Replace custom decompression with LZ4 (`_is_lz4_frame`, `_decompress_loxcc_block_lz4`) and auto-detect frame vs block.
>   - Add strict payload length check before decompressing; retain checksum and size validations.
>   - Minor: add debug logging and clarify docstring args.
> - **Dependencies**:
>   - Add `lz4>=4.4.4` to `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84efbd29a7d7230347767c421eba84e7b87cd7ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->