### PR TITLE
Add HTTP API endpoint listing MQTT topic to Virtual Input name map

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,4 +85,5 @@ COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 11884/udp
+EXPOSE 11885/tcp
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ docker run -d \
   --restart unless-stopped \
   -v $(pwd)/config:/app/config \
   -p 11884:11884/udp \
+  -p 11885:11885/tcp \
   acidcliff/loxmqttrelay
 
 Optionally set -e LOG_LEVEL=DEBUG for more detailed logging
@@ -163,6 +164,7 @@ docker run -d \
   -v /path/to/your/config:/app/config \
   -e LOG_LEVEL=INFO \
   -p 11884:11884/udp \
+  -p 11885:11885/tcp \
   mqttrelay
 ```
 
@@ -180,6 +182,7 @@ docker run -d \
 
 - **Ports**:
   - UDP port (default 11884) for receiving UDP messages
+  - TCP port (default 11885) for the read-only HTTP API (see [HTTP API](#http-api))
 
 ### Example docker-compose.yml
 
@@ -194,6 +197,7 @@ services:
       - LOG_LEVEL=INFO
     ports:
       - "11884:11884/udp"
+      - "11885:11885/tcp"
     restart: unless-stopped
 ```
 
@@ -430,6 +434,34 @@ Caution: This function will assume that every Virtual Input is a possible target
 ### Trigger Manual Sync
 
 Configure your Miniserver to publish any message to `{base_topic}/miniserverevent/startup` on startup to trigger an automatic resync with the Miniserver configuration.
+
+## HTTP API
+
+The relay exposes a small, read-only HTTP API (in addition to the UDP input) for inspecting its runtime state.
+
+```toml
+[http]
+http_api_enabled = true   # start the HTTP API server (default: true)
+http_api_port = 11885     # TCP port to listen on (default: 11885)
+```
+
+### `GET /vi_names`
+
+Returns a JSON object mapping each whitelisted MQTT topic to the **Virtual Input name** it is forwarded to on the Miniserver. The Virtual Input name is the *normalized* topic (`/` and `%` replaced by `_`) — exactly the name the relay uses when writing to `/dev/sps/io/<name>/<value>` — so this tells you how each Virtual Input has to be named in Loxone Config.
+
+```bash
+curl http://<relay-host>:11885/vi_names
+```
+
+```json
+{
+  "device/status": "device_status",
+  "home/living%room/temp": "home_living_room_temp",
+  "sensor_data": "sensor_data"
+}
+```
+
+The list reflects the current whitelist, whether it was loaded from `config.toml` or synced from the Miniserver (see [Automatic Configuration Sync](#automatic-configuration-sync)).
 
 ## Testing Setup
 

--- a/config/default_config.toml
+++ b/config/default_config.toml
@@ -34,6 +34,10 @@ convert_booleans = false
 [udp]
 udp_in_port = 11884
 
+[http]
+http_api_enabled = true
+http_api_port = 11885
+
 [debug]
 mock_ip = ""
 enable_mock = false

--- a/src/loxmqttrelay/config.py
+++ b/src/loxmqttrelay/config.py
@@ -17,6 +17,7 @@ class ConfigSection(Enum):
     TOPICS = "topics"
     PROCESSING = "processing"
     UDP = "udp"
+    HTTP = "http"
     DEBUG = "debug"
 
 @dataclass
@@ -62,6 +63,11 @@ class UdpConfig:
     udp_in_port: int = 11884
 
 @dataclass
+class HttpConfig:
+    http_api_enabled: bool = True
+    http_api_port: int = 11885
+
+@dataclass
 class DebugConfig:
     mock_ip: str = ""
     enable_mock: bool = False
@@ -74,6 +80,7 @@ class AppConfig:
     topics: TopicsConfig = field(default_factory=TopicsConfig)
     processing: ProcessingConfig = field(default_factory=ProcessingConfig)
     udp: UdpConfig = field(default_factory=UdpConfig)
+    http: HttpConfig = field(default_factory=HttpConfig)
     debug: DebugConfig = field(default_factory=DebugConfig)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -263,6 +270,10 @@ class Config:
     @property
     def udp(self) -> UdpConfig:
         return self._config.udp
+
+    @property
+    def http(self) -> HttpConfig:
+        return self._config.http
 
     @property
     def debug(self) -> DebugConfig:

--- a/src/loxmqttrelay/http_api_server.py
+++ b/src/loxmqttrelay/http_api_server.py
@@ -1,0 +1,63 @@
+import orjson
+from aiohttp import web
+
+from loxmqttrelay.config import global_config
+from loxmqttrelay.logging_config import get_lazy_logger
+
+logger = get_lazy_logger(__name__)
+
+
+class HttpApiServer:
+    """Small read-only HTTP API for inspecting the relay's runtime state.
+
+    Currently exposes a single endpoint, ``GET /vi_names``, which returns the
+    mapping of whitelisted MQTT topics to the Virtual Input names they are
+    forwarded to on the Miniserver. The VI name is the *normalized* topic
+    (``/`` and ``%`` replaced by ``_``) - exactly the name the relay uses when
+    writing to ``/dev/sps/io/<name>/<value>`` - so the map tells you how each
+    Virtual Input has to be named in Loxone Config.
+    """
+
+    def __init__(self, data_processor):
+        # data_processor exposes normalize_topic(); reusing it keeps this map in
+        # lock-step with the naming the forward path actually uses.
+        self._data_processor = data_processor
+        self._runner = None
+
+    def build_vi_name_map(self) -> dict:
+        """Return {mqtt_topic: virtual_input_name} for the current whitelist.
+
+        Keys are the whitelisted topics as configured; values are their
+        normalized form, i.e. the name the matching Virtual Input must have on
+        the Miniserver. Sorted by key for a stable, human-friendly response.
+        """
+        mapping = {}
+        for topic in sorted(global_config.topics.topic_whitelist):
+            mapping[topic] = self._data_processor.normalize_topic(topic)
+        return mapping
+
+    async def handle_vi_names(self, request: web.Request) -> web.Response:
+        mapping = self.build_vi_name_map()
+        return web.Response(
+            body=orjson.dumps(mapping),
+            content_type="application/json",
+        )
+
+    def build_app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_get("/vi_names", self.handle_vi_names)
+        return app
+
+    async def start(self) -> None:
+        self._runner = web.AppRunner(self.build_app())
+        await self._runner.setup()
+
+        port = global_config.http.http_api_port
+        site = web.TCPSite(self._runner, "0.0.0.0", port)
+        await site.start()
+        logger.info(f"HTTP-API listening on port {port}")
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None

--- a/src/loxmqttrelay/main.py
+++ b/src/loxmqttrelay/main.py
@@ -11,6 +11,7 @@ from loxmqttrelay.mqtt_client import mqtt_client
 from loxmqttrelay.udp_handler import start_udp_server
 from loxmqttrelay.miniserver_sync import sync_miniserver_whitelist
 from loxmqttrelay.http_miniserver_handler import http_miniserver_handler
+from loxmqttrelay.http_api_server import HttpApiServer
 import loxmqttrelay.utils as utils
 
 # The imports are now handled by __init__.py
@@ -37,14 +38,23 @@ init_rust_logger()
 class MQTTRelay:
     def __init__(self):
         self.miniserver_data_processor = MiniserverDataProcessor(TOPIC, global_config, self, mqtt_client, http_miniserver_handler, orjson)
+        self.http_api_server = HttpApiServer(self.miniserver_data_processor)
 
     async def main(self):
         await self.connect_and_subscribe_mqtt()
         await self.handle_miniserver_sync()
         asyncio.create_task(start_udp_server())
+        await self.start_http_api()
 
         logger.info("MQTT Relay started")
         await asyncio.Future()
+
+    async def start_http_api(self):
+        """Start the read-only HTTP API server if enabled in the config."""
+        if not global_config.http.http_api_enabled:
+            logger.info("HTTP-API disabled by config")
+            return
+        await self.http_api_server.start()
 
     async def handle_miniserver_sync(self):
         """Attempt to sync whitelist with miniserver if enabled"""        

--- a/tests/test_http_api_server.py
+++ b/tests/test_http_api_server.py
@@ -1,0 +1,102 @@
+import socket
+
+import aiohttp
+import orjson
+import pytest
+from aiohttp.test_utils import TestClient, TestServer, make_mocked_request
+
+from loxmqttrelay.config import global_config
+from loxmqttrelay.http_api_server import HttpApiServer
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class FakeProcessor:
+    """Mimics MiniserverDataProcessor.normalize_topic (Rust) in pure Python."""
+
+    def normalize_topic(self, topic: str) -> str:
+        return topic.replace("/", "_").replace("%", "_")
+
+
+@pytest.fixture
+def server():
+    return HttpApiServer(FakeProcessor())
+
+
+def test_build_vi_name_map_normalizes_topics(server):
+    global_config.topics.topic_whitelist = {"device/status", "sensor_data", "home/living%room/temp"}
+
+    mapping = server.build_vi_name_map()
+
+    assert mapping == {
+        "device/status": "device_status",
+        "home/living%room/temp": "home_living_room_temp",
+        "sensor_data": "sensor_data",
+    }
+
+
+def test_build_vi_name_map_is_sorted_by_key(server):
+    global_config.topics.topic_whitelist = {"c", "a", "b"}
+
+    mapping = server.build_vi_name_map()
+
+    assert list(mapping.keys()) == ["a", "b", "c"]
+
+
+def test_build_vi_name_map_empty_whitelist(server):
+    global_config.topics.topic_whitelist = set()
+
+    assert server.build_vi_name_map() == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_vi_names_returns_json(server):
+    global_config.topics.topic_whitelist = {"device/status"}
+
+    request = make_mocked_request("GET", "/vi_names")
+    response = await server.handle_vi_names(request)
+
+    assert response.status == 200
+    assert response.content_type == "application/json"
+    assert orjson.loads(response.body) == {"device/status": "device_status"}
+
+
+@pytest.mark.asyncio
+async def test_vi_names_endpoint_over_http(server):
+    global_config.topics.topic_whitelist = {"a/b", "c"}
+
+    async with TestClient(TestServer(server.build_app())) as client:
+        resp = await client.get("/vi_names")
+
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "application/json"
+        assert await resp.json() == {"a/b": "a_b", "c": "c"}
+
+
+@pytest.mark.asyncio
+async def test_start_binds_port_and_stop_releases(server):
+    global_config.topics.topic_whitelist = {"x/y"}
+    port = _free_port()
+    global_config.http.http_api_port = port
+
+    await server.start()
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{port}/vi_names") as resp:
+                assert resp.status == 200
+                assert await resp.json() == {"x/y": "x_y"}
+    finally:
+        await server.stop()
+
+    # After stop() the port must no longer be served.
+    with pytest.raises(aiohttp.ClientError):
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"http://127.0.0.1:{port}/vi_names",
+                timeout=aiohttp.ClientTimeout(total=1),
+            ):
+                pass

--- a/tests/test_mqtt_relay.py
+++ b/tests/test_mqtt_relay.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 import logging
 import json
 from loxmqttrelay.main import MQTTRelay, TOPIC
@@ -44,6 +44,28 @@ def mock_logger() -> typing.Generator[MagicMock, None, None]:
     """Creates a mocked logger."""
     with patch('loxmqttrelay.main.logger', new_callable=MagicMock) as mock_logger:
         yield mock_logger
+
+@pytest.mark.asyncio
+async def test_start_http_api_enabled(config_instance: Config) -> None:
+    """When enabled, start_http_api starts the HTTP API server."""
+    config_instance._config.http.http_api_enabled = True
+    with patch.object(config_instance, '_load_config', return_value=None):
+        relay = MQTTRelay()
+        relay.http_api_server.start = AsyncMock()
+        await relay.start_http_api()
+        relay.http_api_server.start.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_http_api_disabled(config_instance: Config) -> None:
+    """When disabled, start_http_api does not start the server."""
+    config_instance._config.http.http_api_enabled = False
+    with patch.object(config_instance, '_load_config', return_value=None):
+        relay = MQTTRelay()
+        relay.http_api_server.start = AsyncMock()
+        await relay.start_http_api()
+        relay.http_api_server.start.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 async def test_whitelist_loading_sequence(config_instance: Config, mock_logger: MagicMock) -> None:


### PR DESCRIPTION
Adds a read-only HTTP API server exposing GET /vi_names, which returns a JSON object mapping each whitelisted MQTT topic to the Virtual Input name it is forwarded to on the Miniserver (the normalized topic used in /dev/sps/io/<name>/<value>). This tells users how to name each Virtual Input in Loxone Config.

- New [http] config section (http_api_enabled, http_api_port; default enabled on TCP 11885)
- HttpApiServer built on aiohttp, started from MQTTRelay.main when enabled
- Expose port 11885 in Dockerfile; document the endpoint and ports in the README
- Tests for the topic->VI-name map, the JSON response, the server lifecycle, and the enable/disable toggle


So, obviously, this was vibe coded with Claude but I can't seem to test it. I copied over my config, but the /vi_names is just an empty list and not sure if I did something wrong, the code just flat doesn't work, etc. any help/guidance on this would be appreciated 🙂 The generated tests seem to pass, but not sure if it's crap validating crap.